### PR TITLE
Fix SwapData.deserialize missing return statement causing TypeScript compilation error

### DIFF
--- a/dist/swaps/SwapData.js
+++ b/dist/swaps/SwapData.js
@@ -3,8 +3,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.SwapData = void 0;
 class SwapData {
     static deserialize(data) {
-        if (SwapData.deserializers[data.type] != null) {
-            return new SwapData.deserializers[data.type](data);
+        const deserializer = SwapData.deserializers[data.type];
+        if (deserializer != null) {
+            return new deserializer(data);
         }
         throw new Error(`No deserializer found for swap data type: ${data.type}`);
     }

--- a/dist/swaps/SwapData.js
+++ b/dist/swaps/SwapData.js
@@ -6,6 +6,7 @@ class SwapData {
         if (SwapData.deserializers[data.type] != null) {
             return new SwapData.deserializers[data.type](data);
         }
+        throw new Error(`No deserializer found for swap data type: ${data.type}`);
     }
 }
 exports.SwapData = SwapData;

--- a/dist/swaps/SwapData.js
+++ b/dist/swaps/SwapData.js
@@ -3,9 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.SwapData = void 0;
 class SwapData {
     static deserialize(data) {
-        const deserializer = SwapData.deserializers[data.type];
-        if (deserializer != null) {
-            return new deserializer(data);
+        if (SwapData.deserializers[data.type] != null) {
+            return new SwapData.deserializers[data.type](data);
         }
         throw new Error(`No deserializer found for swap data type: ${data.type}`);
     }

--- a/src/swaps/SwapData.ts
+++ b/src/swaps/SwapData.ts
@@ -7,8 +7,9 @@ export abstract class SwapData implements StorageObject {
   } = {};
 
   static deserialize<T extends SwapData>(data: any): T {
-    if (SwapData.deserializers[data.type] != null) {
-      return new SwapData.deserializers[data.type](data) as unknown as T;
+    const deserializer = SwapData.deserializers[data.type];
+    if (deserializer != null) {
+      return new deserializer(data) as unknown as T;
     }
     throw new Error(`No deserializer found for swap data type: ${data.type}`);
   }

--- a/src/swaps/SwapData.ts
+++ b/src/swaps/SwapData.ts
@@ -1,63 +1,64 @@
-import { ChainSwapType } from "./ChainSwapType";
-import { StorageObject } from "../storage/StorageObject";
+import {ChainSwapType} from "./ChainSwapType";
+import {StorageObject} from "../storage/StorageObject";
 
 export abstract class SwapData implements StorageObject {
-  static deserializers: {
-    [type: string]: new (serialized: any) => any;
-  } = {};
 
-  static deserialize<T extends SwapData>(data: any): T {
-    const deserializer = SwapData.deserializers[data.type];
-    if (deserializer != null) {
-      return new deserializer(data) as unknown as T;
+    static deserializers: {
+        [type: string]: new (serialized: any) => any,
+    } = {};
+
+    static deserialize<T extends SwapData>(data: any): T {
+        if(SwapData.deserializers[data.type]!=null) {
+            return new SwapData.deserializers[data.type](data) as unknown as T;
+        }
+        throw new Error(`No deserializer found for swap data type: ${data.type}`);
     }
-    throw new Error(`No deserializer found for swap data type: ${data.type}`);
-  }
+    abstract getOfferer(): string;
+    abstract setOfferer(newOfferer: string): void;
+    abstract isOfferer(address: string): boolean;
 
-  abstract getOfferer(): string;
-  abstract setOfferer(newOfferer: string): void;
-  abstract isOfferer(address: string): boolean;
+    abstract getClaimer(): string;
+    abstract setClaimer(newClaimer: string): void;
+    abstract isClaimer(address: string): boolean;
 
-  abstract getClaimer(): string;
-  abstract setClaimer(newClaimer: string): void;
-  abstract isClaimer(address: string): boolean;
+    abstract serialize(): any;
 
-  abstract serialize(): any;
+    abstract getType(): ChainSwapType;
 
-  abstract getType(): ChainSwapType;
+    abstract getAmount(): bigint;
 
-  abstract getAmount(): bigint;
+    abstract getToken(): string;
 
-  abstract getToken(): string;
+    abstract isToken(token: string): boolean;
 
-  abstract isToken(token: string): boolean;
+    abstract getExpiry(): bigint;
 
-  abstract getExpiry(): bigint;
+    abstract isPayOut(): boolean;
 
-  abstract isPayOut(): boolean;
+    abstract isPayIn(): boolean;
 
-  abstract isPayIn(): boolean;
+    abstract getClaimHash(): string;
 
-  abstract getClaimHash(): string;
+    abstract getEscrowHash(): string;
 
-  abstract getEscrowHash(): string;
+    abstract getSequence?(): bigint;
 
-  abstract getSequence?(): bigint;
+    abstract getExtraData(): string;
+    abstract getConfirmationsHint(): number;
+    abstract getNonceHint(): bigint;
+    abstract getTxoHashHint(): string;
+    abstract setExtraData(extraData: string): void;
 
-  abstract getExtraData(): string;
-  abstract getConfirmationsHint(): number;
-  abstract getNonceHint(): bigint;
-  abstract getTxoHashHint(): string;
-  abstract setExtraData(extraData: string): void;
+    abstract getSecurityDeposit(): bigint;
 
-  abstract getSecurityDeposit(): bigint;
+    abstract getClaimerBounty(): bigint;
 
-  abstract getClaimerBounty(): bigint;
+    abstract getTotalDeposit(): bigint;
 
-  abstract getTotalDeposit(): bigint;
+    abstract getDepositToken(): string;
+    abstract isDepositToken(token: string): boolean;
 
-  abstract getDepositToken(): string;
-  abstract isDepositToken(token: string): boolean;
+    abstract equals(other: SwapData): boolean;
 
-  abstract equals(other: SwapData): boolean;
 }
+

--- a/src/swaps/SwapData.ts
+++ b/src/swaps/SwapData.ts
@@ -8,8 +8,9 @@ export abstract class SwapData implements StorageObject {
     } = {};
 
     static deserialize<T extends SwapData>(data: any): T {
-        if(SwapData.deserializers[data.type]!=null) {
-            return new SwapData.deserializers[data.type](data) as unknown as T;
+        const deserializer = SwapData.deserializers[data.type];
+        if(deserializer != null) {
+            return new deserializer(data) as unknown as T;
         }
         throw new Error(`No deserializer found for swap data type: ${data.type}`);
     }

--- a/src/swaps/SwapData.ts
+++ b/src/swaps/SwapData.ts
@@ -1,64 +1,62 @@
-import {ChainSwapType} from "./ChainSwapType";
-import {StorageObject} from "../storage/StorageObject";
+import { ChainSwapType } from "./ChainSwapType";
+import { StorageObject } from "../storage/StorageObject";
 
 export abstract class SwapData implements StorageObject {
+  static deserializers: {
+    [type: string]: new (serialized: any) => any;
+  } = {};
 
-    static deserializers: {
-        [type: string]: new (serialized: any) => any,
-    } = {};
-
-    static deserialize<T extends SwapData>(data: any): T {
-        if(SwapData.deserializers[data.type]!=null) {
-            return new SwapData.deserializers[data.type](data) as unknown as T;
-        }
+  static deserialize<T extends SwapData>(data: any): T {
+    if (SwapData.deserializers[data.type] != null) {
+      return new SwapData.deserializers[data.type](data) as unknown as T;
     }
+    throw new Error(`No deserializer found for swap data type: ${data.type}`);
+  }
 
-    abstract getOfferer(): string;
-    abstract setOfferer(newOfferer: string): void;
-    abstract isOfferer(address: string): boolean;
+  abstract getOfferer(): string;
+  abstract setOfferer(newOfferer: string): void;
+  abstract isOfferer(address: string): boolean;
 
-    abstract getClaimer(): string;
-    abstract setClaimer(newClaimer: string): void;
-    abstract isClaimer(address: string): boolean;
+  abstract getClaimer(): string;
+  abstract setClaimer(newClaimer: string): void;
+  abstract isClaimer(address: string): boolean;
 
-    abstract serialize(): any;
+  abstract serialize(): any;
 
-    abstract getType(): ChainSwapType;
+  abstract getType(): ChainSwapType;
 
-    abstract getAmount(): bigint;
+  abstract getAmount(): bigint;
 
-    abstract getToken(): string;
+  abstract getToken(): string;
 
-    abstract isToken(token: string): boolean;
+  abstract isToken(token: string): boolean;
 
-    abstract getExpiry(): bigint;
+  abstract getExpiry(): bigint;
 
-    abstract isPayOut(): boolean;
+  abstract isPayOut(): boolean;
 
-    abstract isPayIn(): boolean;
+  abstract isPayIn(): boolean;
 
-    abstract getClaimHash(): string;
+  abstract getClaimHash(): string;
 
-    abstract getEscrowHash(): string;
+  abstract getEscrowHash(): string;
 
-    abstract getSequence?(): bigint;
+  abstract getSequence?(): bigint;
 
-    abstract getExtraData(): string;
-    abstract getConfirmationsHint(): number;
-    abstract getNonceHint(): bigint;
-    abstract getTxoHashHint(): string;
-    abstract setExtraData(extraData: string): void;
+  abstract getExtraData(): string;
+  abstract getConfirmationsHint(): number;
+  abstract getNonceHint(): bigint;
+  abstract getTxoHashHint(): string;
+  abstract setExtraData(extraData: string): void;
 
-    abstract getSecurityDeposit(): bigint;
+  abstract getSecurityDeposit(): bigint;
 
-    abstract getClaimerBounty(): bigint;
+  abstract getClaimerBounty(): bigint;
 
-    abstract getTotalDeposit(): bigint;
+  abstract getTotalDeposit(): bigint;
 
-    abstract getDepositToken(): string;
-    abstract isDepositToken(token: string): boolean;
+  abstract getDepositToken(): string;
+  abstract isDepositToken(token: string): boolean;
 
-    abstract equals(other: SwapData): boolean;
-
+  abstract equals(other: SwapData): boolean;
 }
-


### PR DESCRIPTION

This prevented projects using `@atomiqlabs/base` from building successfully.

## Solution
- Added a `throw new Error()` statement when no deserializer is found for the given type
- Stored the deserializer in a variable to avoid TypeScript's "Object is possibly undefined" error after the null check

## Changes
1. **Fixed missing return path**: Added error throwing when `SwapData.deserializers[data.type]` is null/undefined
2. **Improved type safety**: Store deserializer in variable so TypeScript can properly narrow the type after null check

## Code Changes
```typescript
// Before
static deserialize<T extends SwapData>(data: any): T {
    if(SwapData.deserializers[data.type]!=null) {
        return new SwapData.deserializers[data.type](data) as unknown as T;
    }
    // Missing return statement!
}

// After  
static deserialize<T extends SwapData>(data: any): T {
    const deserializer = SwapData.deserializers[data.type];
    if (deserializer != null) {
        return new deserializer(data) as unknown as T;
    }
    throw new Error(`No deserializer found for swap data type: ${data.type}`);
}
