### PR TITLE
Add support for versioned contracts

### DIFF
--- a/dist/chains/ChainData.d.ts
+++ b/dist/chains/ChainData.d.ts
@@ -30,6 +30,17 @@ export type ChainData<T extends ChainType> = {
     spvVaultContract: T["SpvVaultContract"];
     spvVaultDataConstructor: new (data: any) => T["SpvVaultData"];
     spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"];
+    defaultVersion?: string;
+    versions?: {
+        [contractVersion: string]: {
+            btcRelay: T["BtcRelay"];
+            swapContract: T["Contract"];
+            swapDataConstructor: new (data: any) => T["Data"];
+            spvVaultContract: T["SpvVaultContract"];
+            spvVaultDataConstructor: new (data: any) => T["SpvVaultData"];
+            spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"];
+        };
+    };
 };
 /**
  * An initializer function that returns populated {@link ChainData} for a given chain based on the passed

--- a/dist/events/types/ChainEvent.d.ts
+++ b/dist/events/types/ChainEvent.d.ts
@@ -12,4 +12,9 @@ export declare class ChainEvent<T extends SwapData> {
         blockTime: number;
         txId: string;
     };
+    /**
+     * Version of the contract that emitted the event
+     */
+    contractVersion?: string;
+    constructor(contractVersion?: string);
 }

--- a/dist/events/types/ChainEvent.js
+++ b/dist/events/types/ChainEvent.js
@@ -7,5 +7,8 @@ exports.ChainEvent = void 0;
  * @category Events
  */
 class ChainEvent {
+    constructor(contractVersion) {
+        this.contractVersion = contractVersion;
+    }
 }
 exports.ChainEvent = ChainEvent;

--- a/dist/events/types/spv_vault/SpvVaultClaimEvent.d.ts
+++ b/dist/events/types/spv_vault/SpvVaultClaimEvent.d.ts
@@ -37,5 +37,5 @@ export declare class SpvVaultClaimEvent extends SpvVaultEvent<SpvVaultEventType.
      * The sequence of this claim (withdrawal) - i.e. the total number of deposits done before this one
      */
     withdrawCount: number;
-    constructor(owner: string, vaultId: bigint, btcTxId: string, recipient: string, executionHash: string, amounts: bigint[], caller: string, frontingAddress: string, withdrawCount: number);
+    constructor(owner: string, vaultId: bigint, btcTxId: string, recipient: string, executionHash: string, amounts: bigint[], caller: string, frontingAddress: string, withdrawCount: number, contractVersion?: string);
 }

--- a/dist/events/types/spv_vault/SpvVaultClaimEvent.js
+++ b/dist/events/types/spv_vault/SpvVaultClaimEvent.js
@@ -8,8 +8,8 @@ const SpvVaultEvent_1 = require("./SpvVaultEvent");
  * @category Events
  */
 class SpvVaultClaimEvent extends SpvVaultEvent_1.SpvVaultEvent {
-    constructor(owner, vaultId, btcTxId, recipient, executionHash, amounts, caller, frontingAddress, withdrawCount) {
-        super(owner, vaultId);
+    constructor(owner, vaultId, btcTxId, recipient, executionHash, amounts, caller, frontingAddress, withdrawCount, contractVersion) {
+        super(owner, vaultId, contractVersion);
         this.eventType = SpvVaultEvent_1.SpvVaultEventType.CLAIM;
         this.btcTxId = btcTxId;
         this.recipient = recipient;

--- a/dist/events/types/spv_vault/SpvVaultCloseEvent.d.ts
+++ b/dist/events/types/spv_vault/SpvVaultCloseEvent.d.ts
@@ -16,5 +16,5 @@ export declare class SpvVaultCloseEvent extends SpvVaultEvent<SpvVaultEventType.
      * A representation of the actual error that has happened
      */
     error: string;
-    constructor(owner: string, vaultId: bigint, btcTxId: string, error: string);
+    constructor(owner: string, vaultId: bigint, btcTxId: string, error: string, contractVersion?: string);
 }

--- a/dist/events/types/spv_vault/SpvVaultCloseEvent.js
+++ b/dist/events/types/spv_vault/SpvVaultCloseEvent.js
@@ -10,8 +10,8 @@ const SpvVaultEvent_1 = require("./SpvVaultEvent");
  * @category Events
  */
 class SpvVaultCloseEvent extends SpvVaultEvent_1.SpvVaultEvent {
-    constructor(owner, vaultId, btcTxId, error) {
-        super(owner, vaultId);
+    constructor(owner, vaultId, btcTxId, error, contractVersion) {
+        super(owner, vaultId, contractVersion);
         this.eventType = SpvVaultEvent_1.SpvVaultEventType.CLOSE;
         this.btcTxId = btcTxId;
         this.error = error;

--- a/dist/events/types/spv_vault/SpvVaultDepositEvent.d.ts
+++ b/dist/events/types/spv_vault/SpvVaultDepositEvent.d.ts
@@ -15,5 +15,5 @@ export declare class SpvVaultDepositEvent extends SpvVaultEvent<SpvVaultEventTyp
      * The sequence of this deposit - i.e. the total number of deposits done before this one
      */
     depositCount: number;
-    constructor(owner: string, vaultId: bigint, amounts: bigint[], depositCount: number);
+    constructor(owner: string, vaultId: bigint, amounts: bigint[], depositCount: number, contractVersion?: string);
 }

--- a/dist/events/types/spv_vault/SpvVaultDepositEvent.js
+++ b/dist/events/types/spv_vault/SpvVaultDepositEvent.js
@@ -8,8 +8,8 @@ const SpvVaultEvent_1 = require("./SpvVaultEvent");
  * @category Events
  */
 class SpvVaultDepositEvent extends SpvVaultEvent_1.SpvVaultEvent {
-    constructor(owner, vaultId, amounts, depositCount) {
-        super(owner, vaultId);
+    constructor(owner, vaultId, amounts, depositCount, contractVersion) {
+        super(owner, vaultId, contractVersion);
         this.eventType = SpvVaultEvent_1.SpvVaultEventType.DEPOSIT;
         this.amounts = amounts;
         this.depositCount = depositCount;

--- a/dist/events/types/spv_vault/SpvVaultEvent.d.ts
+++ b/dist/events/types/spv_vault/SpvVaultEvent.d.ts
@@ -27,5 +27,5 @@ export declare abstract class SpvVaultEvent<C extends SpvVaultEventType = SpvVau
      * ID of the SPV vault (UTXO-controlled vault)
      */
     vaultId: bigint;
-    constructor(owner: string, vaultId: bigint);
+    constructor(owner: string, vaultId: bigint, contractVersion?: string);
 }

--- a/dist/events/types/spv_vault/SpvVaultEvent.js
+++ b/dist/events/types/spv_vault/SpvVaultEvent.js
@@ -21,8 +21,8 @@ var SpvVaultEventType;
  * @category Events
  */
 class SpvVaultEvent extends ChainEvent_1.ChainEvent {
-    constructor(owner, vaultId) {
-        super();
+    constructor(owner, vaultId, contractVersion) {
+        super(contractVersion);
         this.owner = owner;
         this.vaultId = vaultId;
     }

--- a/dist/events/types/spv_vault/SpvVaultFrontEvent.d.ts
+++ b/dist/events/types/spv_vault/SpvVaultFrontEvent.d.ts
@@ -28,5 +28,5 @@ export declare class SpvVaultFrontEvent extends SpvVaultEvent<SpvVaultEventType.
      * Address of the party which fronted the withdrawal
      */
     frontingAddress: string;
-    constructor(owner: string, vaultId: bigint, btcTxId: string, recipient: string, executionHash: string, amounts: bigint[], frontingAddress: string);
+    constructor(owner: string, vaultId: bigint, btcTxId: string, recipient: string, executionHash: string, amounts: bigint[], frontingAddress: string, contractVersion?: string);
 }

--- a/dist/events/types/spv_vault/SpvVaultFrontEvent.js
+++ b/dist/events/types/spv_vault/SpvVaultFrontEvent.js
@@ -8,8 +8,8 @@ const SpvVaultEvent_1 = require("./SpvVaultEvent");
  * @category Events
  */
 class SpvVaultFrontEvent extends SpvVaultEvent_1.SpvVaultEvent {
-    constructor(owner, vaultId, btcTxId, recipient, executionHash, amounts, frontingAddress) {
-        super(owner, vaultId);
+    constructor(owner, vaultId, btcTxId, recipient, executionHash, amounts, frontingAddress, contractVersion) {
+        super(owner, vaultId, contractVersion);
         this.eventType = SpvVaultEvent_1.SpvVaultEventType.FRONT;
         this.btcTxId = btcTxId;
         this.recipient = recipient;

--- a/dist/events/types/spv_vault/SpvVaultOpenEvent.d.ts
+++ b/dist/events/types/spv_vault/SpvVaultOpenEvent.d.ts
@@ -14,5 +14,5 @@ export declare class SpvVaultOpenEvent extends SpvVaultEvent<SpvVaultEventType.O
      * Vault ownership utxo transaction vout
      */
     vout: number;
-    constructor(owner: string, vaultId: bigint, btcTxId: string, vout: number);
+    constructor(owner: string, vaultId: bigint, btcTxId: string, vout: number, contractVersion?: string);
 }

--- a/dist/events/types/spv_vault/SpvVaultOpenEvent.js
+++ b/dist/events/types/spv_vault/SpvVaultOpenEvent.js
@@ -8,8 +8,8 @@ const SpvVaultEvent_1 = require("./SpvVaultEvent");
  * @category Events
  */
 class SpvVaultOpenEvent extends SpvVaultEvent_1.SpvVaultEvent {
-    constructor(owner, vaultId, btcTxId, vout) {
-        super(owner, vaultId);
+    constructor(owner, vaultId, btcTxId, vout, contractVersion) {
+        super(owner, vaultId, contractVersion);
         this.eventType = SpvVaultEvent_1.SpvVaultEventType.OPEN;
         this.btcTxId = btcTxId;
         this.vout = vout;

--- a/dist/events/types/swap/ClaimEvent.d.ts
+++ b/dist/events/types/swap/ClaimEvent.d.ts
@@ -11,5 +11,5 @@ export declare class ClaimEvent<T extends SwapData> extends SwapEvent<T, SwapEve
      * The result of the Claim event, usually either a secret pre-image or transaction hash
      */
     result: string;
-    constructor(escrowHash: string, result: string);
+    constructor(escrowHash: string, result: string, contractVersion?: string);
 }

--- a/dist/events/types/swap/ClaimEvent.js
+++ b/dist/events/types/swap/ClaimEvent.js
@@ -8,8 +8,8 @@ const SwapEvent_1 = require("./SwapEvent");
  * @category Events
  */
 class ClaimEvent extends SwapEvent_1.SwapEvent {
-    constructor(escrowHash, result) {
-        super(escrowHash);
+    constructor(escrowHash, result, contractVersion) {
+        super(escrowHash, contractVersion);
         this.eventType = SwapEvent_1.SwapEventType.CLAIM;
         this.result = result;
     }

--- a/dist/events/types/swap/InitializeEvent.d.ts
+++ b/dist/events/types/swap/InitializeEvent.d.ts
@@ -16,5 +16,5 @@ export declare class InitializeEvent<T extends SwapData> extends SwapEvent<T, Sw
      * A getter for the actual full swap data that was used to initialize the escrow swap
      */
     swapData: () => Promise<T | null>;
-    constructor(escrowHash: string, swapType: ChainSwapType, swapData: () => Promise<T | null>);
+    constructor(escrowHash: string, swapType: ChainSwapType, swapData: () => Promise<T | null>, contractVersion?: string);
 }

--- a/dist/events/types/swap/InitializeEvent.js
+++ b/dist/events/types/swap/InitializeEvent.js
@@ -8,8 +8,8 @@ const SwapEvent_1 = require("./SwapEvent");
  * @category Events
  */
 class InitializeEvent extends SwapEvent_1.SwapEvent {
-    constructor(escrowHash, swapType, swapData) {
-        super(escrowHash);
+    constructor(escrowHash, swapType, swapData, contractVersion) {
+        super(escrowHash, contractVersion);
         this.eventType = SwapEvent_1.SwapEventType.INITIALIZE;
         this.swapType = swapType;
         this.swapData = swapData;

--- a/dist/events/types/swap/SwapEvent.d.ts
+++ b/dist/events/types/swap/SwapEvent.d.ts
@@ -21,5 +21,5 @@ export declare abstract class SwapEvent<T extends SwapData, C extends SwapEventT
      * Identifier of the escrow, usually a hash of the full escrow swap data
      */
     escrowHash: string;
-    constructor(escrowHash: string);
+    constructor(escrowHash: string, contractVersion?: string);
 }

--- a/dist/events/types/swap/SwapEvent.js
+++ b/dist/events/types/swap/SwapEvent.js
@@ -19,8 +19,8 @@ var SwapEventType;
  * @category Events
  */
 class SwapEvent extends ChainEvent_1.ChainEvent {
-    constructor(escrowHash) {
-        super();
+    constructor(escrowHash, contractVersion) {
+        super(contractVersion);
         this.escrowHash = escrowHash;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/base",
-  "version": "13.4.2",
+  "version": "13.5.0",
   "description": "Base classes and interfaces for atomiq protocol",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/src/chains/ChainData.ts
+++ b/src/chains/ChainData.ts
@@ -31,7 +31,19 @@ export type ChainData<T extends ChainType> = {
     swapDataConstructor: new (data: any) => T["Data"],
     spvVaultContract: T["SpvVaultContract"],
     spvVaultDataConstructor: new (data: any) => T["SpvVaultData"],
-    spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"]
+    spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"],
+
+    defaultVersion?: string,
+    versions?: {
+        [contractVersion: string]: {
+            btcRelay: T["BtcRelay"],
+            swapContract: T["Contract"],
+            swapDataConstructor: new (data: any) => T["Data"],
+            spvVaultContract: T["SpvVaultContract"],
+            spvVaultDataConstructor: new (data: any) => T["SpvVaultData"],
+            spvVaultWithdrawalDataConstructor: new (data: any) => T["SpvVaultWithdrawalData"],
+        }
+    }
 };
 
 /**

--- a/src/events/types/ChainEvent.ts
+++ b/src/events/types/ChainEvent.ts
@@ -15,4 +15,13 @@ export class ChainEvent<T extends SwapData> {
         txId: string
     };
 
+    /**
+     * Version of the contract that emitted the event
+     */
+    contractVersion?: string;
+
+    constructor(contractVersion?: string) {
+        this.contractVersion = contractVersion;
+    }
+
 }

--- a/src/events/types/spv_vault/SpvVaultClaimEvent.ts
+++ b/src/events/types/spv_vault/SpvVaultClaimEvent.ts
@@ -45,9 +45,10 @@ export class SpvVaultClaimEvent extends SpvVaultEvent<SpvVaultEventType.CLAIM> {
     constructor(
         owner: string, vaultId: bigint,
         btcTxId: string, recipient: string, executionHash: string, amounts: bigint[],
-        caller: string, frontingAddress: string, withdrawCount: number
+        caller: string, frontingAddress: string, withdrawCount: number,
+        contractVersion?: string
     ) {
-        super(owner, vaultId);
+        super(owner, vaultId, contractVersion);
         this.btcTxId = btcTxId;
         this.recipient = recipient;
         this.executionHash = executionHash;

--- a/src/events/types/spv_vault/SpvVaultCloseEvent.ts
+++ b/src/events/types/spv_vault/SpvVaultCloseEvent.ts
@@ -21,8 +21,8 @@ export class SpvVaultCloseEvent extends SpvVaultEvent<SpvVaultEventType.CLOSE> {
      */
     error: string;
 
-    constructor(owner: string, vaultId: bigint, btcTxId: string, error: string) {
-        super(owner, vaultId);
+    constructor(owner: string, vaultId: bigint, btcTxId: string, error: string, contractVersion?: string) {
+        super(owner, vaultId, contractVersion);
         this.btcTxId = btcTxId;
         this.error = error;
     }

--- a/src/events/types/spv_vault/SpvVaultDepositEvent.ts
+++ b/src/events/types/spv_vault/SpvVaultDepositEvent.ts
@@ -21,8 +21,8 @@ export class SpvVaultDepositEvent extends SpvVaultEvent<SpvVaultEventType.DEPOSI
      */
     depositCount: number;
 
-    constructor(owner: string, vaultId: bigint, amounts: bigint[], depositCount: number) {
-        super(owner, vaultId);
+    constructor(owner: string, vaultId: bigint, amounts: bigint[], depositCount: number, contractVersion?: string) {
+        super(owner, vaultId, contractVersion);
         this.amounts = amounts;
         this.depositCount = depositCount;
     }

--- a/src/events/types/spv_vault/SpvVaultEvent.ts
+++ b/src/events/types/spv_vault/SpvVaultEvent.ts
@@ -31,8 +31,8 @@ export abstract class SpvVaultEvent<C extends SpvVaultEventType = SpvVaultEventT
      */
     vaultId: bigint;
 
-    constructor(owner: string, vaultId: bigint) {
-        super();
+    constructor(owner: string, vaultId: bigint, contractVersion?: string) {
+        super(contractVersion);
         this.owner = owner;
         this.vaultId = vaultId;
     }

--- a/src/events/types/spv_vault/SpvVaultFrontEvent.ts
+++ b/src/events/types/spv_vault/SpvVaultFrontEvent.ts
@@ -36,9 +36,9 @@ export class SpvVaultFrontEvent extends SpvVaultEvent<SpvVaultEventType.FRONT> {
     constructor(
         owner: string, vaultId: bigint,
         btcTxId: string, recipient: string, executionHash: string, amounts: bigint[],
-        frontingAddress: string
+        frontingAddress: string, contractVersion?: string
     ) {
-        super(owner, vaultId);
+        super(owner, vaultId, contractVersion);
         this.btcTxId = btcTxId;
         this.recipient = recipient;
         this.executionHash = executionHash;

--- a/src/events/types/spv_vault/SpvVaultOpenEvent.ts
+++ b/src/events/types/spv_vault/SpvVaultOpenEvent.ts
@@ -19,8 +19,8 @@ export class SpvVaultOpenEvent extends SpvVaultEvent<SpvVaultEventType.OPEN> {
      */
     vout: number;
 
-    constructor(owner: string, vaultId: bigint, btcTxId: string, vout: number) {
-        super(owner, vaultId);
+    constructor(owner: string, vaultId: bigint, btcTxId: string, vout: number, contractVersion?: string) {
+        super(owner, vaultId, contractVersion);
         this.btcTxId = btcTxId;
         this.vout = vout;
     }

--- a/src/events/types/swap/ClaimEvent.ts
+++ b/src/events/types/swap/ClaimEvent.ts
@@ -14,8 +14,8 @@ export class ClaimEvent<T extends SwapData> extends SwapEvent<T, SwapEventType.C
      */
     result: string;
 
-    constructor(escrowHash: string, result: string) {
-        super(escrowHash);
+    constructor(escrowHash: string, result: string, contractVersion?: string) {
+        super(escrowHash, contractVersion);
         this.result = result;
     }
 

--- a/src/events/types/swap/InitializeEvent.ts
+++ b/src/events/types/swap/InitializeEvent.ts
@@ -19,8 +19,8 @@ export class InitializeEvent<T extends SwapData> extends SwapEvent<T, SwapEventT
      */
     swapData: () => Promise<T | null>;
 
-    constructor(escrowHash: string, swapType: ChainSwapType, swapData: () => Promise<T | null>) {
-        super(escrowHash);
+    constructor(escrowHash: string, swapType: ChainSwapType, swapData: () => Promise<T | null>, contractVersion?: string) {
+        super(escrowHash, contractVersion);
         this.swapType = swapType;
         this.swapData = swapData;
     }

--- a/src/events/types/swap/SwapEvent.ts
+++ b/src/events/types/swap/SwapEvent.ts
@@ -25,8 +25,8 @@ export abstract class SwapEvent<T extends SwapData, C extends SwapEventType = Sw
      */
     escrowHash: string;
 
-    constructor(escrowHash: string) {
-        super();
+    constructor(escrowHash: string, contractVersion?: string) {
+        super(contractVersion);
         this.escrowHash = escrowHash;
     }
 


### PR DESCRIPTION
Adds an optional (backwards compatible) versioned contract dictionary in the `ChainData` type, allowing the chain initializers to return multiple contract versions at the same time, making e.g. the older SDK swaps backwards compatible.

Also add a version field to the on-chain event objects, since only a single event listener is used, which subscribes to all the various versions of the contracts deployed.